### PR TITLE
chore: eslint-config-stripes

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@bigtest/interactor": "^0.9.2",
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
-    "@folio/eslint-config-stripes": "^5.2.0",
+    "@folio/eslint-config-stripes": "^6.0.0",
     "@folio/stripes": "^7.0.0",
     "@folio/stripes-cli": "^2.3.0",
     "babel-eslint": "^10.0.0",


### PR DESCRIPTION
Bumped dependency on eslint-config-stripes to 6.0.0

ERM-1971